### PR TITLE
Refactor HttpResponse struct: Replace ContentBody and ContentType enu…

### DIFF
--- a/docs/response.md
+++ b/docs/response.md
@@ -1,0 +1,65 @@
+# Response Object (HttpResponse)
+
+## Overview
+
+`HttpResponse` represents an outgoing HTTP response and provides utilities for sending data back to the client.
+
+## Creating a Response Object
+
+HttpResponse is automatically passed to route handlers.
+The return type of a route handler is HttpResponse.
+
+Example:
+
+```rust
+async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+    let body = req.text().unwrap_or("No body".to_string());
+    res.ok().text(format!("Received: {}", body))
+}
+```
+
+## Sending Status code
+
+Sends a status code to the client.
+
+- Example
+
+```rust
+let res = ripress::context::HttpResponse::new();
+res.status(code)
+```
+
+Sends the status code specified by the `code` parameter.
+
+## Status code helpers
+
+- Example
+
+```rust
+let res = ripress::context::HttpResponse::new();
+res.ok(); // 200 OK - Request succeeded
+res.bad_request(); // 400 Bad Request - Client sent invalid data
+res.not_found(); // 404 Not Found - Resource does not exist
+res.internal_server_error(); // 500 Internal Server Error - Something went wrong on the server
+```
+
+## Send data to the client
+
+### JSON
+
+Sends a JSON response to the client.
+
+```rust
+use serde_json::json;
+
+let json_body = json!({"key": "value"});
+let res = ripress::context::HttpResponse::new().json(json_body);
+```
+
+### Text
+
+Sends a text response to the client.
+
+```rust
+let res = ripress::context::HttpResponse::new().text("Hello, World!");
+```

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,73 +1,144 @@
 use actix_web::Responder;
-use serde::Serialize;
 
+use crate::types::{ResponseContentBody, ResponseContentType};
+
+/// Represents an http response going to the client
+///
+/// This struct holds various properties of an HTTP response, such as
+/// status code, body content, and content type.
+///
+/// # Example
+/// ```
+/// use ripress::context::HttpResponse;
+/// let req = HttpResponse::new();
+/// ```
+///
+/// # Fields
+/// - `status_code`: Stores status code of the response.
+/// - `body`: Contains the response body, which may be JSON, text, or form data.
+/// - `content_type`: The content type of the response.
 pub struct HttpResponse {
+    // Status code specified by the developer
     status_code: i32,
-    body: ContentBody,
-    content_type: ContentType,
-}
 
-#[derive(PartialEq, Debug, Clone)]
-pub(crate) enum ContentType {
-    JSON,
-    TEXT,
-}
+    // Response body content
+    body: ResponseContentBody,
 
-#[derive(Serialize)]
-pub(crate) enum ContentBody {
-    JSON(serde_json::Value),
-    TEXT(String),
-}
-
-impl ContentBody {
-    fn new_text<T: Into<String>>(text: T) -> Self {
-        ContentBody::TEXT(text.into())
-    }
+    // Content type of the response
+    content_type: ResponseContentType,
 }
 
 impl HttpResponse {
     pub fn new() -> Self {
         HttpResponse {
             status_code: 200,
-            body: ContentBody::TEXT(String::new()),
-            content_type: ContentType::JSON,
+            body: ResponseContentBody::TEXT(String::new()),
+            content_type: ResponseContentType::JSON,
         }
     }
+
+    /// Sets the status code of the response.
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    /// res.status(404); // Sets the status code to 404
+    /// ```
 
     pub fn status(mut self, code: i32) -> Self {
         self.status_code = code;
         return self;
     }
 
+    /// Sets the status code to 200 (OK).
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    /// res.ok(); // Sets the status code to 200
+    /// ```
+
     pub fn ok(mut self) -> Self {
         self.status_code = 200;
         return self;
     }
+
+    /// Sets the status code to 400 (Bad Request).
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    /// res.bad_request(); // Sets the status code to 400
+    /// ```
 
     pub fn bad_request(mut self) -> Self {
         self.status_code = 400;
         return self;
     }
 
+    /// Sets the status code to 404 (Not Found).
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    /// res.not_found(); // Sets the status code to 404
+    /// ```
+
     pub fn not_found(mut self) -> Self {
         self.status_code = 401;
         return self;
     }
+
+    /// Sets the status code to 500 (Internal Server Error).
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    /// res.internal_server_error(); // Sets the status code to 500
+    /// ```
 
     pub fn internal_server_error(mut self) -> Self {
         self.status_code = 500;
         return self;
     }
 
+    /// Sets the response body to JSON.
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// use serde_json::json;
+    ///
+    /// let json_body = json!({"key": "value"});
+    /// let res = HttpResponse::new();
+    ///
+    /// res.json(json_body); // Sets the response body to JSON
+    /// ```
+
     pub fn json(mut self, json: serde_json::Value) -> Self {
-        self.body = ContentBody::JSON(json);
-        self.content_type = ContentType::JSON;
+        self.body = ResponseContentBody::JSON(json);
+        self.content_type = ResponseContentType::JSON;
         return self;
     }
 
+    /// Sets the response body to text.
+    ///
+    /// # Example
+    /// ```
+    /// use ripress::context::HttpResponse;
+    /// let res = HttpResponse::new();
+    ///
+    /// res.text("Hello, World!"); // Sets the response body to text
+    /// ```
+
     pub fn text<T: Into<String>>(mut self, text: T) -> Self {
-        self.body = ContentBody::new_text(text);
-        self.content_type = ContentType::TEXT;
+        self.body = ResponseContentBody::new_text(text);
+        self.content_type = ResponseContentType::TEXT;
         return self;
     }
 
@@ -75,10 +146,10 @@ impl HttpResponse {
         let body = self.body;
         actix_web::http::StatusCode::from_u16(self.status_code as u16)
             .map(|status| match body {
-                ContentBody::JSON(json) => actix_web::HttpResponse::build(status)
+                ResponseContentBody::JSON(json) => actix_web::HttpResponse::build(status)
                     .content_type("application/json")
                     .json(json),
-                ContentBody::TEXT(text) => actix_web::HttpResponse::build(status)
+                ResponseContentBody::TEXT(text) => actix_web::HttpResponse::build(status)
                     .content_type("text/plain")
                     .body(text),
             })
@@ -102,11 +173,11 @@ impl HttpResponse {
         self.status_code
     }
 
-    pub fn get_content_type(&self) -> ContentType {
+    pub fn get_content_type(&self) -> ResponseContentType {
         self.content_type.clone()
     }
 
-    pub fn get_body(self) -> ContentBody {
+    pub fn get_body(self) -> ResponseContentBody {
         self.body
     }
 }

--- a/src/tests/response_test.rs
+++ b/src/tests/response_test.rs
@@ -1,16 +1,17 @@
 #[cfg(test)]
 mod tests {
-    use crate::response::{ContentBody, ContentType, HttpResponse};
+    use crate::response::HttpResponse;
+    use crate::types::{ResponseContentBody, ResponseContentType};
     use serde_json::json;
 
     #[test]
     fn test_default_response() {
         let response = HttpResponse::new();
         assert_eq!(response.get_status_code(), 200);
-        assert_eq!(response.get_content_type(), ContentType::JSON);
+        assert_eq!(response.get_content_type(), ResponseContentType::JSON);
 
         // Edge case: Check default body content
-        if let ContentBody::TEXT(body) = response.get_body() {
+        if let ResponseContentBody::TEXT(body) = response.get_body() {
             assert_eq!(body, "");
         } else {
             panic!("Expected TEXT body");
@@ -31,8 +32,8 @@ mod tests {
     fn test_json_response() {
         let json_body = json!({"key": "value"});
         let response = HttpResponse::new().json(json_body.clone());
-        assert_eq!(response.get_content_type(), ContentType::JSON);
-        if let ContentBody::JSON(body) = response.get_body() {
+        assert_eq!(response.get_content_type(), ResponseContentType::JSON);
+        if let ResponseContentBody::JSON(body) = response.get_body() {
             assert_eq!(body, json_body);
         } else {
             panic!("Expected JSON body");
@@ -41,7 +42,7 @@ mod tests {
         // Edge case: Empty JSON object
         let empty_json = json!({});
         let response = HttpResponse::new().json(empty_json.clone());
-        if let ContentBody::JSON(body) = response.get_body() {
+        if let ResponseContentBody::JSON(body) = response.get_body() {
             assert_eq!(body, empty_json);
         } else {
             panic!("Expected JSON body");
@@ -52,8 +53,8 @@ mod tests {
     fn test_text_response() {
         let text_body = "Hello, World!";
         let response = HttpResponse::new().text(text_body);
-        assert_eq!(response.get_content_type(), ContentType::TEXT);
-        if let ContentBody::TEXT(body) = response.get_body() {
+        assert_eq!(response.get_content_type(), ResponseContentType::TEXT);
+        if let ResponseContentBody::TEXT(body) = response.get_body() {
             assert_eq!(body, text_body);
         } else {
             panic!("Expected TEXT body");
@@ -61,7 +62,7 @@ mod tests {
 
         // Edge case: Empty text body
         let response = HttpResponse::new().text("");
-        if let ContentBody::TEXT(body) = response.get_body() {
+        if let ResponseContentBody::TEXT(body) = response.get_body() {
             assert_eq!(body, "");
         } else {
             panic!("Expected TEXT body");

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,7 @@
+use serde::Serialize;
+
+// HttpRequest types
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum RequestBodyType {
     JSON,
@@ -12,4 +16,24 @@ pub enum RequestBodyContent {
     TEXT(String),
     JSON(serde_json::Value),
     FORM(String),
+}
+
+// HttpResponse types
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum ResponseContentType {
+    JSON,
+    TEXT,
+}
+
+#[derive(Serialize)]
+pub(crate) enum ResponseContentBody {
+    JSON(serde_json::Value),
+    TEXT(String),
+}
+
+impl ResponseContentBody {
+    pub fn new_text<T: Into<String>>(text: T) -> Self {
+        ResponseContentBody::TEXT(text.into())
+    }
 }


### PR DESCRIPTION
…ms with ResponseContentBody and ResponseContentType for improved clarity and organization. Enhance documentation with examples for setting status codes and response bodies. Update tests to reflect changes in enum usage.