### PR TITLE
Change visibility of `exec_middleware` and `ApiError` enum to crate s…

### DIFF
--- a/src/app/api_error.rs
+++ b/src/app/api_error.rs
@@ -2,7 +2,7 @@ use crate::res::HttpResponse;
 use std::convert::Infallible;
 
 #[derive(Debug)]
-pub enum ApiError {
+pub(crate) enum ApiError {
     Generic(HttpResponse),
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,7 +6,7 @@ use crate::{
 use hyper::{Body, Request};
 use url::form_urlencoded::Serializer;
 
-pub async fn exec_middleware(
+pub(crate) async fn exec_middleware(
     mut req: Request<Body>,
     middleware: Middleware,
 ) -> Result<Request<Body>, ApiError> {


### PR DESCRIPTION
…cope

- Updated `exec_middleware` function to be accessible only within the crate by changing its visibility from public to `pub(crate)`.
- Modified `ApiError` enum to also have crate-level visibility, enhancing encapsulation and control over error handling within the module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Restricted internal error type visibility to the crate for better encapsulation; no behavioral changes.
  - Limited middleware execution helper visibility to the crate; no impact on runtime behavior.

- Notes
  - No user-facing changes. Potentially impacts external integrations relying on previously public internals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->