### PR TITLE
Add binary response handling and related tests

### DIFF
--- a/docs/api-reference/request.md
+++ b/docs/api-reference/request.md
@@ -491,10 +491,13 @@ async fn main() {
 }
 
 async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
-    let bytes = req.bytes().unwrap();
-    println!("Bytes: {:?}", bytes);
-
-    res.ok()
+    match req.bytes() {
+        Ok(bytes) => {
+            println!("Bytes: {:?}", bytes);
+            res.ok()
+        }
+        Err(e) => res.bad_request().text(format!("Invalid binary body: {}", e)),
+    }
 }
 ```
 

--- a/docs/api-reference/request.md
+++ b/docs/api-reference/request.md
@@ -470,6 +470,36 @@ async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
 
 Returns `Result<J, String>` where `J` is your deserialized type.
 
+## Binary Body
+
+```rust
+use ripress::{
+    app::App,
+    context::{HttpRequest, HttpResponse},
+    types::RouterFns,
+};
+
+#[tokio::main]
+
+async fn main() {
+    let mut app = App::new();
+
+    app.get("/", handler);
+
+    app.listen(3000, || println!("Server running on port 3000"))
+        .await;
+}
+
+async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+    let bytes = req.bytes().unwrap();
+    println!("Bytes: {:?}", bytes);
+
+    res.ok()
+}
+```
+
+Returns `Result<&[u8], String>`.
+
 ### Text Body
 
 ```rust

--- a/docs/example/request.md
+++ b/docs/example/request.md
@@ -238,6 +238,31 @@ async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
 }
 ```
 
+## Handling BINARY Body
+
+```rust
+use ripress::{
+    app::App,
+    context::{HttpRequest, HttpResponse},
+    types::RouterFns,
+};
+
+#[tokio::main]
+async fn main() {
+    let mut app = App::new();
+
+    app.get("/", handler);
+
+    app.listen(3000, || {}).await;
+}
+async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+    match req.bytes() {
+        Ok(bytes) => res.ok().text(format!("Received bytes: {:?}", bytes)),
+        Err(e) => res.bad_request().text(format!("Invalid binary body: {}", e)),
+    }
+}
+```
+
 ## Handling Form Data
 
 ```rust

--- a/docs/example/request.md
+++ b/docs/example/request.md
@@ -251,13 +251,14 @@ use ripress::{
 async fn main() {
     let mut app = App::new();
 
-    app.get("/", handler);
+    app.post("/", handler);
 
     app.listen(3000, || {}).await;
 }
+
 async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
     match req.bytes() {
-        Ok(bytes) => res.ok().text(format!("Received bytes: {:?}", bytes)),
+        Ok(bytes) => res.ok().bytes(bytes),
         Err(e) => res.bad_request().text(format!("Invalid binary body: {}", e)),
     }
 }

--- a/docs/guides/request/overview.md
+++ b/docs/guides/request/overview.md
@@ -46,6 +46,7 @@ Ripress makes it easy to extract data from different parts of the request:
 ### Request Body
 
 - **JSON** - Automatic deserialization to your Rust structs
+- **BINARY** - Access raw bytes from the request body
 - **Form Data** - Parse URL-encoded form submissions
 - **Plain Text** - Raw text content from the request body
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -108,6 +108,7 @@ async fn main() {
     app.get("/get-cookie-test", get_cookie_test);
     app.get("/multiple-cookies-test", get_multi_cookie_test);
     app.get("/cookie-options-test", get_cookie_with_options_test);
+    app.get("/binary-test", binary_test);
 
     // streaming tests
     app.get("/stream-text", stream_text);
@@ -291,6 +292,11 @@ async fn secure_handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
 async fn get_cookie_test(_req: HttpRequest, res: HttpResponse) -> HttpResponse {
     res.ok()
         .set_cookie("test-cookie", "value", CookieOptions::default())
+}
+
+async fn binary_test(_req: HttpRequest, res: HttpResponse) -> HttpResponse {
+    let bytes = vec![1, 2, 3, 4, 5];
+    res.bytes(bytes)
 }
 
 async fn get_cookie_with_options_test(_req: HttpRequest, res: HttpResponse) -> HttpResponse {

--- a/src/req/body/mod.rs
+++ b/src/req/body/mod.rs
@@ -63,8 +63,7 @@ pub mod form_data;
 /// with validation and encoding support.
 pub mod text_data;
 
-use std::fmt::Display;
-
+use bytes::Bytes;
 // Re-export commonly used types for convenience
 pub use form_data::FormData;
 pub use text_data::{TextData, TextDataError};
@@ -110,7 +109,7 @@ impl RequestBody {
         }
     }
 
-    pub(crate) fn new_binary(bytes: Vec<u8>) -> Self {
+    pub(crate) fn new_binary(bytes: Bytes) -> Self {
         RequestBody {
             content_type: RequestBodyType::BINARY,
             content: RequestBodyContent::BINARY(bytes),
@@ -412,6 +411,7 @@ impl ToString for RequestBodyType {
 /// ```rust
 /// use ripress::req::body::{RequestBodyContent, FormData, TextData};
 /// use serde_json::json;
+/// use bytes::Bytes;
 ///
 /// // The enum variants hold the actual data
 /// let json_content = RequestBodyContent::JSON(json!({"key": "value"}));
@@ -423,7 +423,7 @@ impl ToString for RequestBodyType {
 /// let text_data = TextData::new(String::from("Hello"));
 /// let text_content = RequestBodyContent::TEXT(text_data);
 ///
-/// let bytes = vec![1, 2, 3, 4, 5];
+/// let bytes = Bytes::new();
 /// let binary_content = RequestBodyContent::BINARY(bytes);
 ///
 /// let empty_content = RequestBodyContent::EMPTY;
@@ -503,11 +503,11 @@ pub enum RequestBodyContent {
 
     ///  Binary content data.
     ///
-    ///  Contains a `Vec<u8>` that holds binary data.
+    ///  Contains a `byte::Bytes` that holds binary data.
     ///
     /// # Examples
     /// - File uploads
-    BINARY(Vec<u8>),
+    BINARY(Bytes),
 
     /// No content (empty body).
     ///

--- a/src/req/body/mod.rs
+++ b/src/req/body/mod.rs
@@ -63,6 +63,8 @@ pub mod form_data;
 /// with validation and encoding support.
 pub mod text_data;
 
+use std::fmt::Display;
+
 // Re-export commonly used types for convenience
 pub use form_data::FormData;
 pub use text_data::{TextData, TextDataError};
@@ -105,6 +107,13 @@ impl RequestBody {
         RequestBody {
             content_type: RequestBodyType::TEXT,
             content: RequestBodyContent::TEXT(text),
+        }
+    }
+
+    pub(crate) fn new_binary(bytes: Vec<u8>) -> Self {
+        RequestBody {
+            content_type: RequestBodyType::BINARY,
+            content: RequestBodyContent::BINARY(bytes),
         }
     }
 
@@ -295,6 +304,16 @@ pub enum RequestBodyType {
     /// - OAuth token requests
     FORM,
 
+    /// Binary data content type (`application/octet-stream`).
+    ///
+    /// Used for binary data, such as files or images, that are transmitted as
+    /// raw bytes without any specific structure or encoding.
+    ///
+    /// # Common Use Cases
+    /// -  File uploads
+    /// -  Image transmission
+    BINARY,
+
     /// Empty content type (no body).
     ///
     /// Represents the absence of a request body, typically used for HTTP methods
@@ -361,6 +380,7 @@ impl ToString for RequestBodyType {
             RequestBodyType::JSON => "application/json".to_string(),
             RequestBodyType::TEXT => "text/plain".to_string(),
             RequestBodyType::FORM => "application/x-www-form-urlencoded".to_string(),
+            RequestBodyType::BINARY => "application/octet-stream".to_string(),
             RequestBodyType::EMPTY => "".to_string(),
         }
     }
@@ -403,6 +423,9 @@ impl ToString for RequestBodyType {
 /// let text_data = TextData::new(String::from("Hello"));
 /// let text_content = RequestBodyContent::TEXT(text_data);
 ///
+/// let bytes = vec![1, 2, 3, 4, 5];
+/// let binary_content = RequestBodyContent::BINARY(bytes);
+///
 /// let empty_content = RequestBodyContent::EMPTY;
 ///
 /// // Pattern matching for processing
@@ -415,6 +438,9 @@ impl ToString for RequestBodyType {
 ///     }
 ///     RequestBodyContent::TEXT(text) => {
 ///         println!("Text content: {:?}", text.as_str());
+///     }
+///     RequestBodyContent::BINARY(bytes) => {
+///         println!("Binary content: {:?}", bytes);
 ///     }
 ///     RequestBodyContent::EMPTY => {
 ///         println!("No body content");
@@ -474,6 +500,14 @@ pub enum RequestBodyContent {
     /// - Contact forms
     /// - Simple key-value parameter sets
     FORM(FormData),
+
+    ///  Binary content data.
+    ///
+    ///  Contains a `Vec<u8>` that holds binary data.
+    ///
+    /// # Examples
+    /// - File uploads
+    BINARY(Vec<u8>),
 
     /// No content (empty body).
     ///

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -596,15 +596,12 @@ impl HttpRequest {
             }
             RequestBodyType::TEXT => {
                 let body_bytes = to_bytes(req.body_mut()).await;
-
-                let body_string = match body_bytes {
-                    Ok(bytes) => TextData::from_bytes(bytes.as_ref().to_vec()),
+                match body_bytes {
+                    Ok(bytes) => match TextData::from_bytes(bytes.as_ref().to_vec()) {
+                        Ok(text) => RequestBody::new_text(text),
+                        Err(_) => RequestBody::new_binary(bytes),
+                    },
                     Err(err) => return Err(err),
-                };
-
-                match body_string {
-                    Ok(text) => RequestBody::new_text(text),
-                    Err(_) => RequestBody::new_text(TextData::new(String::new())),
                 }
             }
             RequestBodyType::BINARY => {

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -605,7 +605,7 @@ impl HttpRequest {
                     Ok(bytes) => RequestBody::new_binary(bytes),
                     Err(err) => {
                         eprintln!("Error while parsing binary body: {}", err);
-                        RequestBody::new_binary(Bytes::new())
+                        return Err(err);
                     }
                 }
             }

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -291,7 +291,7 @@ impl HttpRequest {
 
         if body.content_type == RequestBodyType::BINARY {
             if let RequestBodyContent::BINARY(ref bytes) = body.content {
-                Ok(bytes)
+                Ok(bytes.as_ref())
             } else {
                 Err(String::from("Invalid Binary Content"))
             }

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     req::body::{FormData, RequestBody, RequestBodyContent, RequestBodyType, TextData},
     types::HttpMethods,
 };
+use bytes::Bytes;
 use cookie::Cookie;
 use futures::StreamExt;
 use hyper::{Body, Request, body::to_bytes, header::HOST};
@@ -273,14 +274,14 @@ impl HttpRequest {
         self.body.content_type == content_type
     }
 
-    pub fn bytes(&self) -> Result<&Vec<u8>, String> {
+    pub fn bytes(&self) -> Result<&[u8], String> {
         let body = &self.body;
 
         if body.content_type == RequestBodyType::BINARY {
             if let RequestBodyContent::BINARY(ref bytes) = body.content {
                 Ok(bytes)
             } else {
-                Err(String::from("Invalid JSON content"))
+                Err(String::from("Invalid Binary Content"))
             }
         } else {
             Err(format!(
@@ -601,10 +602,10 @@ impl HttpRequest {
                 let body_bytes = to_bytes(req.body_mut()).await;
 
                 match body_bytes {
-                    Ok(bytes) => RequestBody::new_binary(bytes.to_vec()),
+                    Ok(bytes) => RequestBody::new_binary(bytes),
                     Err(err) => {
                         eprintln!("Error while parsing binary body: {}", err);
-                        RequestBody::new_binary(vec![])
+                        RequestBody::new_binary(Bytes::new())
                     }
                 }
             }

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -515,7 +515,7 @@ impl HttpRequest {
 
         let content_type = req
             .headers()
-            .get("Content-Type")
+            .get(hyper::header::CONTENT_TYPE)
             .and_then(|val| val.to_str().ok())
             .map(determine_content_type)
             .unwrap_or(RequestBodyType::EMPTY);

--- a/src/res/mod.rs
+++ b/src/res/mod.rs
@@ -424,6 +424,12 @@ impl HttpResponse {
         return self;
     }
 
+    pub fn bytes(mut self, bytes: Vec<u8>) -> Self {
+        self.body = ResponseContentBody::new_binary(bytes);
+        self.content_type = ResponseContentType::BINARY;
+        return self;
+    }
+
     /// Sets a header in the response.
     ///
     /// # Example
@@ -676,6 +682,10 @@ impl HttpResponse {
                     .status(self.status_code.as_u16())
                     .header("Content-Type", "text/html")
                     .body(Body::from(html)),
+                ResponseContentBody::BINARY(bytes) => Response::builder()
+                    .status(self.status_code.as_u16())
+                    .header("Content-Type", "application/octet-stream")
+                    .body(Body::from(bytes)),
             }
             .unwrap();
 

--- a/src/res/mod.rs
+++ b/src/res/mod.rs
@@ -424,8 +424,8 @@ impl HttpResponse {
         return self;
     }
 
-    pub fn bytes(mut self, bytes: Vec<u8>) -> Self {
-        self.body = ResponseContentBody::new_binary(bytes);
+    pub fn bytes<T: Into<Bytes>>(mut self, bytes: T) -> Self {
+        self.body = ResponseContentBody::new_binary(bytes.into());
         self.content_type = ResponseContentType::BINARY;
         return self;
     }

--- a/src/tests/response_test.rs
+++ b/src/tests/response_test.rs
@@ -224,9 +224,6 @@ mod tests {
         let content_type = determine_content_type("image/png");
         assert_eq!(content_type, RequestBodyType::BINARY);
 
-        let content_type = determine_content_type("application/vnd.custom+json");
-        assert_eq!(content_type, RequestBodyType::JSON);
-
         let content_type = determine_content_type("application/xml");
         assert_eq!(content_type, RequestBodyType::TEXT);
     }

--- a/src/tests/response_test.rs
+++ b/src/tests/response_test.rs
@@ -3,22 +3,13 @@ mod tests {
     use crate::context::HttpRequest;
     use crate::req::body::RequestBodyType;
     use crate::req::body::TextData;
+    use crate::req::determine_content_type;
     use crate::req::origin_url::Url;
     use crate::res::response_headers::ResponseHeaders;
     use crate::res::response_status::StatusCode;
     use crate::types::HttpMethods;
     use crate::types::HttpRequestError;
     use serde_json::json;
-
-    fn determine_content_type(content_type: &str) -> RequestBodyType {
-        if content_type == "application/json" {
-            return RequestBodyType::JSON;
-        } else if content_type == "application/x-www-form-urlencoded" {
-            return RequestBodyType::FORM;
-        } else {
-            RequestBodyType::TEXT
-        }
-    }
 
     #[test]
     fn test_get_query() {
@@ -222,7 +213,7 @@ mod tests {
         assert_eq!(content_type, RequestBodyType::JSON);
 
         let content_type = determine_content_type("");
-        assert_eq!(content_type, RequestBodyType::TEXT);
+        assert_eq!(content_type, RequestBodyType::BINARY);
 
         let content_type = determine_content_type("application/x-www-form-urlencoded");
         assert_eq!(content_type, RequestBodyType::FORM);

--- a/src/tests/response_test.rs
+++ b/src/tests/response_test.rs
@@ -217,6 +217,18 @@ mod tests {
 
         let content_type = determine_content_type("application/x-www-form-urlencoded");
         assert_eq!(content_type, RequestBodyType::FORM);
+
+        let content_type = determine_content_type("application/octet-stream");
+        assert_eq!(content_type, RequestBodyType::BINARY);
+
+        let content_type = determine_content_type("image/png");
+        assert_eq!(content_type, RequestBodyType::BINARY);
+
+        let content_type = determine_content_type("application/vnd.custom+json");
+        assert_eq!(content_type, RequestBodyType::JSON);
+
+        let content_type = determine_content_type("application/xml");
+        assert_eq!(content_type, RequestBodyType::TEXT);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use crate::app::box_future;
 use crate::req::HttpRequest;
 use crate::res::HttpResponse;
+use bytes::Bytes;
 use hyper::Method;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -13,7 +14,7 @@ pub(crate) enum ResponseContentBody {
     TEXT(String),
     HTML(String),
     JSON(serde_json::Value),
-    BINARY(Vec<u8>),
+    BINARY(Bytes),
 }
 
 impl ResponseContentBody {
@@ -29,7 +30,7 @@ impl ResponseContentBody {
         ResponseContentBody::HTML(html.into())
     }
 
-    pub(crate) fn new_binary(bytes: Vec<u8>) -> Self {
+    pub(crate) fn new_binary(bytes: Bytes) -> Self {
         ResponseContentBody::BINARY(bytes)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,7 @@ pub(crate) enum ResponseContentBody {
     TEXT(String),
     HTML(String),
     JSON(serde_json::Value),
+    BINARY(Vec<u8>),
 }
 
 impl ResponseContentBody {
@@ -27,12 +28,17 @@ impl ResponseContentBody {
     pub(crate) fn new_html<T: Into<String>>(html: T) -> Self {
         ResponseContentBody::HTML(html.into())
     }
+
+    pub(crate) fn new_binary(bytes: Vec<u8>) -> Self {
+        ResponseContentBody::BINARY(bytes)
+    }
 }
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ResponseContentType {
     TEXT,
     JSON,
     HTML,
+    BINARY,
 }
 
 pub(crate) type Fut = Pin<Box<dyn Future<Output = HttpResponse> + Send + 'static>>;

--- a/tests/src/request.spec.ts
+++ b/tests/src/request.spec.ts
@@ -79,6 +79,9 @@ test.describe("Request Tests", () => {
   test("Set and get text body", async ({ request }) => {
     const textResponse = await request.post("/text-test", {
       data: "test",
+      headers: {
+        "Content-Type": "text/plain",
+      },
     });
 
     expect(textResponse.status()).toBe(200);

--- a/tests/src/response.spec.ts
+++ b/tests/src/response.spec.ts
@@ -249,13 +249,13 @@ test.describe("Response Tests", () => {
   //     expect(body).toContain("chunk2");
   // });
   //
-  // test("Binary response", async ({request}) => {
-  //     const response = await request.get("/binary-test");
-  //
-  //     expect(response.status()).toBe(200);
-  //     expect(response.headers()["content-type"]).toBe("application/octet-stream");
-  //
-  //     const buffer = await response.body();
-  //     expect(buffer).toBeInstanceOf(Buffer);
-  // });
+  test("Binary response", async ({ request }) => {
+    const response = await request.get("/binary-test");
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toBe("application/octet-stream");
+
+    const buffer = await response.body();
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
 });

--- a/tests/src/response.spec.ts
+++ b/tests/src/response.spec.ts
@@ -253,7 +253,9 @@ test.describe("Response Tests", () => {
     const response = await request.get("/binary-test");
 
     expect(response.status()).toBe(200);
-    expect(response.headers()["content-type"]).toBe("application/octet-stream");
+    expect(response.headers()["content-type"]).toContain(
+      "application/octet-stream"
+    );
 
     const buffer = await response.body();
     expect(buffer).toBeInstanceOf(Buffer);


### PR DESCRIPTION
- Introduced a new endpoint `/binary-test` to handle binary data responses.
- Updated `ResponseContentBody` and `RequestBody` to support binary content types.
- Enhanced `HttpRequest` and `HttpResponse` implementations to manage binary data.
- Added tests for binary response functionality to ensure correct behavior and content type handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for binary request and response bodies (application/octet-stream).
  * Public API to read raw request bytes and to send binary responses.
  * Unknown or invalid MIME types now default to binary handling.
  * Added a test endpoint that returns a fixed binary payload.

* **Tests**
  * Enabled binary response test and added binary test route.
  * Updated text body test to include an explicit Content-Type header.

* **Documentation**
  * Expanded docs and examples for creating and handling binary payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->