### PR TITLE
Improve file upload middleware error handling and simplify file tracking

### DIFF
--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -290,10 +290,10 @@ impl HttpRequest {
         let body = &self.body;
 
         if body.content_type == RequestBodyType::BINARY {
-            if let RequestBodyContent::BINARY(ref bytes) = body.content {
-                Ok(bytes.as_ref())
-            } else {
-                Err(String::from("Invalid Binary Content"))
+            match &body.content {
+                RequestBodyContent::BINARY(bytes) => Ok(bytes.as_ref()),
+                RequestBodyContent::BinaryWithFields(bytes, _) => Ok(bytes.as_ref()),
+                _ => Err(String::from("Invalid Binary Content")),
             }
         } else {
             Err(format!(

--- a/tests/src/request.spec.ts
+++ b/tests/src/request.spec.ts
@@ -377,30 +377,30 @@ test.describe("Request Tests", () => {
     expect(body.description).toBe("A test user with multiple fields");
   });
 
-  // test("Multipart form data with file upload", async ({ request }) => {
-  //   // Create a test file buffer
-  //   const testFileContent = Buffer.from(
-  //     "This is a test file content for upload"
-  //   );
+  test("Multipart form data with file upload", async ({ request }) => {
+    // Create a test file buffer
+    const testFileContent = Buffer.from(
+      "This is a test file content for upload"
+    );
 
-  //   const response = await request.post("/multipart-file-test", {
-  //     multipart: {
-  //       name: "Test User",
-  //       file: {
-  //         name: "test.txt",
-  //         mimeType: "text/plain",
-  //         buffer: testFileContent,
-  //       },
-  //     },
-  //   });
+    const response = await request.post("/multipart-file-test", {
+      multipart: {
+        name: "Test User",
+        file: {
+          name: "test.txt",
+          mimeType: "text/plain",
+          buffer: testFileContent,
+        },
+      },
+    });
 
-  //   expect(response.status()).toBe(200);
-  //   const body = await response.json();
-  //   expect(body.name).toBe("Test User");
-  //   expect(body.fileName).toBe("test.txt");
-  //   expect(body.fileSize).toBe(testFileContent.length);
-  //   expect(body.mimeType).toBe("text/plain");
-  // });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.name).toBe("Test User");
+    expect(body.fileName).toBe("test.txt");
+    expect(body.fileSize).toBe(testFileContent.length);
+    expect(body.mimeType).toBe("text/plain");
+  });
 
   // test("Multipart form data with multiple files", async ({ request }) => {
   //   const file1 = Buffer.from("Content of first file");


### PR DESCRIPTION
- Enhanced error logging in the file upload middleware to include specific error messages when reading request bytes fails.
- Simplified the tracking of uploaded files by removing the `FileInfo` struct and directly storing filenames.
- Updated the handling of form fields to ensure that the generated filenames are correctly associated with their respective field names.
- Cleaned up commented-out code in the request tests to enable multipart form data tests, ensuring better coverage for file upload scenarios.