### PR TITLE
Add box_future and box_future_middleware functions to helpers

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,6 +5,7 @@ use crate::{
     app::{Middleware, api_error::ApiError},
     req::{HttpRequest, query_params::QueryParams},
     res::HttpResponse,
+    types::{Fut, FutMiddleware},
 };
 use hyper::{Body, Request, Response};
 use routerify::RequestInfo;
@@ -290,4 +291,18 @@ pub(crate) fn extract_quoted_or_token(input: &str) -> &str {
     } else {
         val.split(';').next().unwrap_or(val).trim()
     }
+}
+
+pub(crate) fn box_future<F>(future: F) -> Fut
+where
+    F: Future<Output = HttpResponse> + Send + 'static,
+{
+    Box::pin(future)
+}
+
+pub(crate) fn box_future_middleware<F>(future: F) -> FutMiddleware
+where
+    F: Future<Output = (HttpRequest, Option<HttpResponse>)> + Send + 'static,
+{
+    Box::pin(future)
 }

--- a/src/tests/app_test.rs
+++ b/src/tests/app_test.rs
@@ -7,8 +7,9 @@ async fn _test_handler(_req: HttpRequest, res: HttpResponse) -> HttpResponse {
 #[cfg(test)]
 mod tests {
     use crate::{
-        app::{App, api_error::ApiError, box_future},
+        app::{App, api_error::ApiError},
         context::HttpResponse,
+        helpers::box_future,
         req::HttpRequest,
         types::{HttpMethods, RouterFns},
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-use crate::app::box_future;
+use crate::helpers::box_future;
 use crate::req::HttpRequest;
 use crate::res::HttpResponse;
 use bytes::Bytes;
@@ -36,9 +36,7 @@ impl ResponseContentBody {
             ResponseContentBody::BINARY(bytes) => bytes.len(),
         }
     }
-}
 
-impl ResponseContentBody {
     pub(crate) fn new_text<T: Into<String>>(text: T) -> Self {
         ResponseContentBody::TEXT(text.into())
     }
@@ -59,6 +57,7 @@ impl ResponseContentBody {
         ResponseContentBody::BINARY(bytes.into())
     }
 }
+
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub(crate) enum ResponseContentType {
     TEXT,


### PR DESCRIPTION
Introduce two new utility functions, box_future and box_future_middleware, to the helpers module for easier handling of futures in middleware. Update relevant imports in types and app modules to utilize these new functions, enhancing code organization and readability.