### PR TITLE
Update documentation examples across multiple modules to improve clar…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Quick Start
 //!
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::{app::App, types::RouterFns};
 //!
 //! #[tokio::main]
@@ -50,7 +50,7 @@
 //! ## Advanced Examples
 //!
 //! ### RESTful API with JSON
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::{app::App, types::RouterFns};
 //! use serde::{Deserialize, Serialize};
 //!
@@ -98,7 +98,7 @@
 //! ```
 //!
 //! ### File Upload with Middleware
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::{app::App, middlewares::file_upload::file_upload, types::RouterFns};
 //!
 //! #[tokio::main]

--- a/src/middlewares/mod.rs
+++ b/src/middlewares/mod.rs
@@ -49,7 +49,7 @@
 //!
 //! Middlewares can be registered globally or for specific routes using the [`App`] builder methods:
 //!
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::app::App;
 //! use ripress::middlewares::cors::CorsConfig;
 //! use ripress::middlewares::logger::LoggerConfig;
@@ -96,7 +96,7 @@
 //!
 //! You can create custom middlewares using the pre/post middleware methods:
 //!
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::app::App;
 //!
 //! let mut app = App::new();
@@ -120,7 +120,7 @@
 //!
 //! For production applications, consider this middleware stack:
 //!
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::app::App;
 //!
 //! let mut app = App::new();
@@ -225,7 +225,7 @@ pub mod cors;
 ///
 /// The logger middleware requires a `tracing` subscriber to be initialized in your application:
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// // Simple console logging
 /// tracing_subscriber::fmt::init();
 ///
@@ -327,7 +327,7 @@ pub mod logger;
 ///
 /// ## Configuration
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::app::App;
 /// use ripress::middlewares::file_upload::{FileUploadConfiguration, file_upload};
 ///
@@ -395,44 +395,6 @@ pub mod logger;
 /// });
 /// ```
 ///
-/// ### Client-Side Examples
-///
-/// #### JavaScript Binary Upload
-/// ```no_run,ignore
-/// const fileInput = document.getElementById('fileInput');
-/// const file = fileInput.files[0];
-///
-/// fetch('/upload', {
-///     method: 'POST',
-///     body: file,
-///     headers: {
-///         'Content-Type': file.type
-///     }
-/// });
-/// ```
-///
-/// #### JavaScript Multipart Form
-/// ```no_run,ignore
-/// const formData = new FormData();
-/// formData.append('file1', file1);
-/// formData.append('file2', file2);
-/// formData.append('description', 'My uploaded files');
-///
-/// fetch('/upload', {
-///     method: 'POST',
-///     body: formData
-/// });
-/// ```
-///
-/// #### HTML Form
-/// ```html
-/// <form action="/upload" method="post" enctype="multipart/form-data">
-///     <input type="file" name="files" multiple>
-///     <input type="text" name="description" placeholder="Description">
-///     <input type="submit" value="Upload">
-/// </form>
-/// ```
-///
 /// ## Security Considerations
 ///
 /// - **File Type Validation**: Always validate uploaded file types in your route handlers
@@ -489,7 +451,7 @@ pub mod file_upload;
 ///
 /// ## Configuration Examples
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::app::App;
 /// use ripress::middlewares::rate_limiter::RateLimiterConfig;
 /// use std::time::Duration;
@@ -560,7 +522,7 @@ pub mod file_upload;
 ///
 ///
 /// ### Custom Error Responses
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::middlewares::rate_limiter::RateLimiterConfig;
 /// use ripress::app::App;
 ///
@@ -583,7 +545,7 @@ pub mod file_upload;
 /// ### Single Server
 /// The default in-memory rate limiting works well for single-server deployments:
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::middlewares::rate_limiter::RateLimiterConfig;
 /// use std::time::Duration;
 /// use ripress::app::App;
@@ -601,7 +563,7 @@ pub mod file_upload;
 /// ### Multiple Servers (Future)
 /// For distributed deployments, consider Redis-backed rate limiting:
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::middlewares::rate_limiter::RateLimiterConfig;
 /// use ripress::app::App;
 ///
@@ -1196,7 +1158,7 @@ pub mod compression;
 /// ### Header Precedence
 /// The shield middleware should be applied early in the middleware chain:
 ///
-/// ```no_run,ignore
+/// ```no_run
 /// use ripress::app::App;
 ///
 /// let mut app = App::new();

--- a/src/req/body/mod.rs
+++ b/src/req/body/mod.rs
@@ -19,38 +19,6 @@
 /// This struct enforces consistency between the content type and the actual data format,
 /// preventing common mistakes like sending JSON data with a form content type. Each
 /// constructor method automatically sets the appropriate content type header.
-///
-/// # Examples
-///
-/// ```ignore
-/// use ripress::req::body::{RequestBody, FormData, TextData};
-///
-/// use serde_json::json;
-///
-/// // JSON body
-/// let json_body = RequestBody::new_json(json!({
-///     "username": "alice",
-///     "email": "alice@example.com"
-/// }));
-///
-/// // Form data body
-/// let mut form = FormData::new();
-/// form.insert("username", "alice");
-/// form.insert("password", "secret");
-/// let form_body = RequestBody::new_form(form);
-///
-/// // Text body
-/// let text_data = TextData::new(String::from("Hello, world!"));
-/// let text_body = RequestBody::new_text(text_data);
-///
-/// // Binary body
-/// use bytes::Bytes;
-/// let binary_data = Bytes::from_static(b"\xDE\xAD\xBE\xEF");
-/// let binary_body = RequestBody::new_binary(binary_data);
-///
-/// // Usage in HTTP client
-/// // client.post("https://api.example.com/users").body(json_body).send().await?;
-/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct RequestBody {
     /// The actual body content data
@@ -114,19 +82,6 @@ impl RequestBody {
     ///
     /// A new `RequestBody` instance with `TEXT` content type
     ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ripress::req::body::{RequestBody, RequestBodyType};
-    /// use ripress::req::body::text_data::TextData;
-    ///
-    /// let text_data = TextData::new(String::from("Hello, server!"));
-    /// let body = RequestBody::new_text(text_data);
-    ///
-    /// assert_eq!(body.content_type, RequestBodyType::TEXT);
-    /// // body.content will be RequestBodyContent::TEXT(text_data)
-    /// ```
-    ///
     /// # Use Cases
     ///
     /// - Sending plain text messages
@@ -153,16 +108,6 @@ impl RequestBody {
     /// # Returns
     ///
     /// A new `RequestBody` instance with `BINARY` content type
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ripress::req::body::{RequestBody, RequestBodyType};
-    ///
-    /// let bytes = Bytes::new();
-    /// let binary_content = RequestBody::new_binary(bytes);
-    /// assert_eq!(binary_content.content_type, RequestBodyType::BINARY);
-    /// ```
     ///
     /// # Use Cases
     ///
@@ -220,20 +165,6 @@ impl RequestBody {
     ///
     /// A new `RequestBody` instance with `FORM` content type
     ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ripress::req::body::{RequestBody, RequestBodyType, FormData};
-    ///
-    /// let mut form = FormData::new();
-    /// form.insert("username", "alice");
-    /// form.insert("password", "secret123");
-    /// form.insert("remember_me", "on");
-    ///
-    /// let body = RequestBody::new_form(form);
-    /// assert_eq!(body.content_type, RequestBodyType::FORM);
-    /// ```
-    ///
     /// # Use Cases
     ///
     /// - HTML form submissions (login, registration, etc.)
@@ -269,40 +200,6 @@ impl RequestBody {
     /// - Any serializable struct (with `#[derive(Serialize)]`)
     /// - Primitive types (numbers, strings, booleans)
     /// - Collections (Vec, HashMap, etc.)
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ripress::req::body::{RequestBody, RequestBodyType};
-    /// use serde_json::json;
-    /// use serde::Serialize;
-    ///
-    /// // Using json! macro
-    /// let body1 = RequestBody::new_json(json!({
-    ///     "name": "Alice",
-    ///     "age": 30,
-    ///     "active": true
-    /// }));
-    ///
-    /// // Using a serializable struct
-    /// #[derive(Serialize)]
-    /// struct User {
-    ///     id: u64,
-    ///     email: String,
-    /// }
-    ///
-    /// let user = User {
-    ///     id: 123,
-    ///     email: "user@example.com".to_string(),
-    /// };
-    /// let body2 = RequestBody::new_json(serde_json::to_value(user).unwrap());
-    ///
-    /// // Using primitive values
-    /// let body3 = RequestBody::new_json("simple string");
-    /// let body4 = RequestBody::new_json(vec![1, 2, 3, 4, 5]);
-    ///
-    /// assert_eq!(body1.content_type, RequestBodyType::JSON);
-    /// ```
     ///
     /// # Use Cases
     ///

--- a/src/req/mod.rs
+++ b/src/req/mod.rs
@@ -105,44 +105,76 @@
 //! The HttpRequest supports multiple body content types with type-safe access methods:
 //!
 //! ### JSON Content
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::context::HttpRequest;
+//! use ripress::context::HttpResponse;
+//! use serde::{Deserialize, Serialize};
+//!
 //! // Deserialize JSON directly into structs
-//! match req.json::<MyStruct>() {
-//!     Ok(data) => { /* handle structured data */ }
-//!     Err(e) => { /* handle parsing error */ }
+//!
+//! #[derive(Deserialize, Serialize)]
+//! struct MyStruct;
+//!
+//! async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+//!     match req.json::<MyStruct>() {
+//!         Ok(data) => { /* handle structured data */ }
+//!         Err(e) => { /* handle parsing error */ }
+//!     }
+//!
+//!     res.ok()
 //! }
 //! ```
 //!
 //! ### Form Data
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::context::HttpRequest;
+//! use ripress::context::HttpResponse;
+//!
 //! // Access form fields from application/x-www-form-urlencoded
-//! match req.form_data() {
-//!     Ok(form) => {
-//!         let username = form.get("username").unwrap_or("");
-//!         let password = form.get("password").unwrap_or("");
+//! async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+//!     match req.form_data() {
+//!         Ok(form) => {
+//!             let username = form.get("username").unwrap_or("");
+//!             let password = form.get("password").unwrap_or("");
+//!         }
+//!         Err(e) => { /* handle error */ }
 //!     }
-//!     Err(e) => { /* handle error */ }
+//!
+//!     res.ok()
 //! }
 //! ```
 //!
 //! ### Text Content
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::context::HttpRequest;
+//! use ripress::context::HttpResponse;
+//!
 //! // Get raw text content
-//! match req.text() {
-//!     Ok(text_content) => println!("Received text: {}", text_content),
-//!     Err(e) => println!("Not text content: {}", e),
+//! async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+//!     match req.text() {
+//!         Ok(text_content) => println!("Received text: {}", text_content),
+//!         Err(e) => println!("Not text content: {}", e),
+//!     }
+//!
+//!     res.ok()
 //! }
 //! ```
 //!
 //! ### Binary Data
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::context::HttpRequest;
+//! use ripress::context::HttpResponse;
+//!
 //! // Access raw binary data
-//! match req.bytes() {
-//!     Ok(binary_data) => {
-//!         println!("Received {} bytes", binary_data.len());
-//!         // Process binary data (file upload, image, etc.)
+//! async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+//!     match req.bytes() {
+//!         Ok(binary_data) => {
+//!             println!("Received {} bytes", binary_data.len());
+//!             // Process binary data (file upload, image, etc.)
+//!         }
+//!         Err(e) => println!("Not binary content: {}", e),
 //!     }
-//!     Err(e) => println!("Not binary content: {}", e),
+//!     res.ok().text("Binary data processed")
 //! }
 //! ```
 //!
@@ -182,7 +214,12 @@
 //! ## Advanced Usage Patterns
 //!
 //! ### Middleware Data Sharing
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::app::App;
+//! use ripress::types::RouterFns;
+//!
+//! let mut app = App::new();
+//!
 //! // In middleware
 //! app.use_pre_middleware(None, |mut req, res| async move {
 //!     // Add authentication data
@@ -203,7 +240,12 @@
 //! ```
 //!
 //! ### Cookie Management
-//! ```no_run,ignore
+//! ```no_run
+//! use ripress::app::App;
+//! use ripress::types::RouterFns;
+//!
+//! let mut app = App::new();
+//!
 //! app.get("/profile", |req, res| async move {
 //!     // Check for session cookie
 //!     match req.get_cookie("session_id") {
@@ -219,8 +261,12 @@
 //! ```
 //!
 //! ### Content Type Detection
-//! ```no_run,ignore
+//! ```no_run
 //! use ripress::req::body::RequestBodyType;
+//! use ripress::app::App;
+//! use ripress::types::RouterFns;
+//!
+//! let mut app = App::new();
 //!
 //! app.post("/upload", |req, res| async move {
 //!     if req.is(RequestBodyType::JSON) {

--- a/src/res/mod.rs
+++ b/src/res/mod.rs
@@ -641,14 +641,14 @@ impl HttpResponse {
     /// Returns `Self` for method chaining.
     ///
     /// # Example
-    /// ```ignore
-    /// use ripress::res::HttpResponse;
+    /// ```no_run
+    /// use ripress::context::HttpResponse;
+    /// use ripress::context::HttpRequest;
     ///
-    /// // Send a file as the response
-    /// let res = HttpResponse::new()
-    ///     .ok()
-    ///     .send_file("static/image.png")
-    ///     .await;
+    /// async fn handler(req: HttpRequest, res: HttpResponse) -> HttpResponse {
+    ///     // Send a file as the response
+    ///     res.ok().send_file("static/image.png").await
+    /// }
     /// ```
     pub async fn send_file(mut self, path: &'static str) -> Self {
         let file = tokio::fs::read(path).await;


### PR DESCRIPTION
…ity and consistency

- Changed code block annotations from `no_run,ignore` to `no_run` in various examples to prevent execution during tests.
- Enhanced example clarity by ensuring proper usage of imports and structuring for `HttpRequest`, `HttpResponse`, and middleware examples.
- Removed outdated example sections in `RequestBody` documentation to streamline content and focus on relevant usage patterns.
- Overall improvements aim to facilitate better understanding and usability of the Ripress framework's documentation.