### PR TITLE
Implement pre-middleware response header management

### DIFF
--- a/ripress/src/middlewares/cors.rs
+++ b/ripress/src/middlewares/cors.rs
@@ -2,7 +2,7 @@
 use crate::{
     context::HttpResponse,
     req::HttpRequest,
-    types::{MiddlewareOutput, HttpMethods},
+    types::{HttpMethods, MiddlewareOutput},
 };
 
 /// Builtin CORS (Cross-Origin Resource Sharing) Middleware
@@ -419,7 +419,10 @@ pub(crate) fn cors(
             if req_clone.method == HttpMethods::OPTIONS {
                 return (req_clone, Some(res.ok()));
             }
-            (req_clone, None) 
+            // Return the modified response so exec_pre_middleware can capture the headers
+            // and merge them into the final response. We use a special marker to indicate
+            // this is a "continue" response, not a short-circuit.
+            (req_clone, Some(res))
         })
     }
 }


### PR DESCRIPTION
- Introduced `PreMiddlewareResponseHeaders` struct to store headers modified by pre-middleware.
- Updated `exec_pre_middleware` to capture and insert these headers into the request extensions.
- Enhanced the response handling in the `App` struct to merge pre-middleware headers into the final response.
- Adjusted CORS middleware to return modified responses for header capturing, improving middleware integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header handling in middleware to ensure pre-middleware headers are properly included in final responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->